### PR TITLE
PHP 8: each() is deprecated since 7.2.0, gone in 8.0.0

### DIFF
--- a/astat_aip.class.inc.php
+++ b/astat_aip.class.inc.php
@@ -1445,7 +1445,7 @@ class AStat_AIP extends AStat_root
       if (true) // if(!is_adviser())
       {
         reset($this->config);
-        while (list($key, $val) = each($this->config))
+        foreach ($this->config as $key=>$val)
         {
           if(isset($_POST['f_'.$key]))
           {


### PR DESCRIPTION
Simply use foreach() as in other places.

Reported at https://piwigo.org/forum/viewtopic.php?pid=182424#p182424
